### PR TITLE
Update Facebook.php

### DIFF
--- a/src/Api/Apis/Provider/Facebook.php
+++ b/src/Api/Apis/Provider/Facebook.php
@@ -140,7 +140,7 @@ class Facebook extends AbstractApi
      */
     public function post($identityToken, $message, $link = null, $pictureId = null)
     {
-        if (empty($text) && empty($link['url']))
+        if (empty($message) && empty($link['url']))
         {
             throw new BadMethodCallException('Either a text or a link url must be supplied.');
         }


### PR DESCRIPTION
Hi, the $text variable does not exist in the post() method so it's always throwing on exception